### PR TITLE
Blank Images problem fix when using Streamoji in TableViewCell

### DIFF
--- a/Streamoji/Classes/Extensions/UITextView+Emojis.swift
+++ b/Streamoji/Classes/Extensions/UITextView+Emojis.swift
@@ -27,6 +27,21 @@ extension UITextView {
             self?.applyEmojis(emojis, rendering: rendering)
         }
     }
+    
+    /// - Parameter emojis: A dictionary of emoji keyed by its shortcode.
+    /// - Parameter rendering: The rendering options. Defaults to `.highQuality`.
+    /// - Parameter delay: num of seconds to delay async operation `(example : 1.0,  0.1,  0.3, 2.0)`
+    public func configureEmojisWithDelay(_ emojis: [String: EmojiSource], rendering: EmojiRendering = .highQuality, delay : Double?) {
+        self.applyEmojisWithDelay(emojis, rendering: rendering, delay : delay)
+        
+        NotificationCenter.default.addObserver(
+            forName: UITextView.textDidChangeNotification,
+            object: self,
+            queue: .main
+        ) { [weak self] _ in
+            self?.applyEmojisWithDelay(emojis, rendering: rendering, delay : delay)
+        }
+    }
 }
 
 // MARK: Private
@@ -44,6 +59,16 @@ extension UITextView {
         let newCount = attributedText.string.count
         customEmojiViews.forEach { $0.removeFromSuperview() }
         addEmojiImagesIfNeeded(rendering: rendering)
+        selectedRange = NSRange(location: range.location - (count - newCount), length: range.length)
+    }
+    
+    private func applyEmojisWithDelay(_ emojis: [String: EmojiSource], rendering: EmojiRendering, delay : Double?) {
+        let range = selectedRange
+        let count = attributedText?.string.count ?? 0
+        self.attributedText = attributedText.insertingEmojis(emojis, rendering: rendering)
+        let newCount = attributedText.string.count
+        customEmojiViews.forEach { $0.removeFromSuperview() }
+        addEmojiImagesIfNeededWithDelay(rendering: rendering, delay : delay)
         selectedRange = NSRange(location: range.location - (count - newCount), length: range.length)
     }
     
@@ -102,6 +127,65 @@ extension UITextView {
                 
                 self.textContainerView.addSubview(emojiView)
             }
+        })
+    }
+    
+    private func addEmojiImagesIfNeededWithDelay(rendering: EmojiRendering, delay : Double?) {
+        attributedText.enumerateAttributes(in: NSRange(location: 0, length: attributedText.length), options: [], using: { attributes, crange, _ in
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + (delay ?? 0.0), execute: {
+                guard
+                    let emojiAttachment = attributes[NSAttributedString.Key.attachment] as? NSTextAttachment,
+                    let position1 = self.position(from: self.beginningOfDocument, offset: crange.location),
+                    let position2 = self.position(from: position1, offset: crange.length),
+                    let range = self.textRange(from: position1, to: position2),
+                    let emojiData = emojiAttachment.contents,
+                    let emoji = try? JSONDecoder().decode(EmojiSource.self, from: emojiData)
+                else {
+                    return
+                }
+                
+                let rect = self.firstRect(for: range)
+                
+                let emojiView = EmojiView(frame: rect)
+                emojiView.backgroundColor = self.backgroundColor
+                emojiView.isUserInteractionEnabled = false
+                
+                switch emoji {
+                case let .character(character):
+                    emojiView.label.text = character
+                case let .imageUrl(imageUrl):
+                    guard renderViews[emoji] == nil else {
+                        break
+                    }
+                    
+                    if let url = URL(string: imageUrl) {
+                        let renderView = UIImageView(frame: rect)
+                        renderView.setFromURL(url, rendering: rendering)
+                        renderViews[emoji] = renderView
+                        self.window?.addSubview(renderView)
+                        renderView.alpha = 0
+                    }
+                case let .imageAsset(imageAsset):
+                    guard renderViews[emoji] == nil else {
+                        break
+                    }
+                    
+                    let renderView = UIImageView(frame: rect)
+                    renderView.setFromAsset(imageAsset, rendering: rendering)
+                    renderViews[emoji] = renderView
+                    self.window?.addSubview(renderView)
+                    renderView.alpha = 0
+                case .alias:
+                    break
+                }
+                
+                if let view = renderViews[emoji] {
+                    emojiView.setFromRenderView(view)
+                }
+                
+                self.textContainerView.addSubview(emojiView)
+            })
         })
     }
 }


### PR DESCRIPTION
Hi there, 

First of all, thanks for the great library as it is one of the life savers for iOS devs, at least for me 👏 👏 

My task was binding some text with custom emoticons to UITextView which is inside UITableViewCell. Thanks to Stremoji, it was showing the emoticons. However when I tested it like scrolling the UITableView, I have noticed that library is a bit buggy as it shows blank images when the invisible cells reappear. I have checked the issues and seen one open issue similar to the my problem (https://github.com/GetStream/Streamoji/issues/4). 

I have decided the fork the library and find a solution on my own. After digging a lot, I find a solution by giving a delay value for the **addEmojisIfNeeded** function. The operation was already async but with no delay. Giving a delay value fixed the situation for my side. I have duplicated the functions ..WithDelay postfix and new param delay : Double?

People who face the same problem can use the funcs that I have created. I could have added delay param intto your funcs but didn't want to break your example. 

I posted a demo with two versions. The left one on the video uses configureEmojis, the right one on the video uses configureEmojisWithDelay of 0.5

I also provided my example repo as shown below:
https://github.com/mehmetdelikaya/EmojiExample

https://user-images.githubusercontent.com/16878744/183697591-cf658fe1-b34d-4028-aa19-76ebf15b534a.mov


